### PR TITLE
Render jicofo dumps

### DIFF
--- a/src/main/kotlin/Conference.kt
+++ b/src/main/kotlin/Conference.kt
@@ -45,7 +45,7 @@ class Conference : RComponent<ConferenceProps, ConferenceState>() {
         }
         // TODO: do we know that when this method runs state.numericalKeys will always be empty?
         if (state.numericalKeys.isEmpty() && props.confData != undefined) {
-            extractKeys(props.confData!!.first())
+            extractKeys(props.confData!!)
         }
 
         if ((state.epIds == undefined || state.epIds.isEmpty()) && !usingLiveData()) {
@@ -80,11 +80,19 @@ class Conference : RComponent<ConferenceProps, ConferenceState>() {
         }
     }
 
-    private fun extractKeys(data: dynamic) {
-        console.log("Extracting keys from ", data)
+    private fun extractKeys(data: List<dynamic>) {
+        // This may turn out to be too slow for large dumps.
+        val dataList = mutableListOf<dynamic>()
+        for (i in 1 until data.size) {
+            dataList.add(data[i])
+        }
         setState {
-            numericalKeys = getAllKeysWithValuesThat(data) { it is Number }
-            nonNumericalKeys = getAllKeysWithValuesThat(data) { it !is Number }
+            numericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it is Number }
+            }.toSet().toList()
+            nonNumericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it !is Number }
+            }.toSet().toList()
         }
     }
 

--- a/src/main/kotlin/DumpViewer.kt
+++ b/src/main/kotlin/DumpViewer.kt
@@ -43,10 +43,27 @@ class DumpViewer : RComponent<DumpViewerProps, DumpViewerState>() {
                 reader.readAsText(props.file)
             }
             else -> {
-                child(Conference::class) {
-                    attrs {
-                        id = getConfId(state.data)
-                        confData = state.data
+                val data = state.data as List<dynamic>
+                val jicofo = try {
+                    val clientProtocol = JSON.parse<dynamic>(data[0][2]).clientProtocol as String
+                    clientProtocol.contains("jicofo", ignoreCase = true)
+                } catch (e: Exception) {
+                    false
+                }
+                console.log("Rendering a ${if (jicofo) "jicofo" else "JVB"} conference.")
+                if (jicofo) {
+                    child(JicofoConference::class) {
+                        attrs {
+                            id = getJicofoConfId(data)
+                            confData = data
+                        }
+                    }
+                } else {
+                    child(Conference::class) {
+                        attrs {
+                            id = getConfId(data)
+                            confData = data
+                        }
                     }
                 }
             }
@@ -57,6 +74,11 @@ class DumpViewer : RComponent<DumpViewerProps, DumpViewerState>() {
 private fun getConfId(data: List<dynamic>?): String {
     return data?.asSequence()
         ?.map { it.id }
+        ?.first { it != undefined } as? String ?: "No conf ID found"
+}
+private fun getJicofoConfId(data: List<dynamic>?): String {
+    return data?.asSequence()
+        ?.map { it.confName }
         ?.first { it != undefined } as? String ?: "No conf ID found"
 }
 

--- a/src/main/kotlin/JicofoConference.kt
+++ b/src/main/kotlin/JicofoConference.kt
@@ -1,0 +1,243 @@
+import graphs.ChartCollection
+import kotlinx.browser.window
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.await
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.css.paddingLeft
+import kotlinx.css.paddingTop
+import kotlinx.css.pct
+import kotlinx.html.js.onClickFunction
+import react.RBuilder
+import react.RComponent
+import react.RProps
+import react.RState
+import react.dom.div
+import react.dom.h2
+import react.dom.p
+import react.setState
+import styled.css
+import styled.styledDiv
+
+class JicofoConference : RComponent<JicofoConferenceProps, JicofoConferenceState>() {
+    private val eps: MutableMap<String, Endpoint> = mutableMapOf()
+    private var chartCollection: ChartCollection? = null
+    private var job: Job? = null
+
+    init {
+        state.epIds = arrayOf()
+        state.expanded = false
+        state.dataByEp = null
+        state.numericalKeys = emptyList()
+        state.nonNumericalKeys = emptyList()
+    }
+
+    override fun componentDidMount() {
+        // Start the fetch data job if there's a URL to query
+        if (usingLiveData()) {
+            job = GlobalScope.launch { fetchDataLoop(props.baseRestApiUrl!!) }
+        }
+        // TODO: do we know that when this method runs state.numericalKeys will always be empty?
+        if (state.numericalKeys.isEmpty() && props.confData != undefined) {
+            extractKeys(props.confData!!.first())
+        }
+
+        if ((state.epIds == undefined || state.epIds.isEmpty()) && !usingLiveData()) {
+            val confData = props.confData!!
+            // We need to extract all epIds present in all the data
+            val allEpIds = confData.flatMap {
+                val epIds = getEpIds(it).toList()
+                epIds
+            }.toSet()
+            val dataByEp = mutableMapOf<String, MutableList<dynamic>>()
+            confData.forEach { confDataEntry ->
+                if (confDataEntry.timestamp == undefined) {
+                    return@forEach
+                }
+                val timestamp = confDataEntry.timestamp as Number
+                val epIds = getEpIds(confDataEntry)
+                epIds.forEach { epId ->
+                    val epData = confDataEntry.participants[epId]
+                    // Set the timestamp in the object we'll pass down, since it's at a higher
+                    // level
+                    epData.timestamp = timestamp
+                    val existingEpData = dataByEp.getOrPut(epId) { mutableListOf() }
+                    existingEpData.add(epData)
+                }
+            }
+            val name = confData.asSequence().map { it.name }.first { it != undefined } ?: "No conf name found"
+            setState {
+                epIds = allEpIds.toTypedArray()
+                this.dataByEp = dataByEp
+                this.name = name
+            }
+        }
+    }
+
+    private fun extractKeys(data: dynamic) {
+        setState {
+            numericalKeys = getAllKeysWithValuesThat(data) { it is Number }
+            nonNumericalKeys = getAllKeysWithValuesThat(data) { it !is Number }
+        }
+    }
+
+    override fun componentWillUnmount() {
+        job?.cancel("Unmounting")
+    }
+
+    // TODO: we need this function because react doesn't do a deep comparison on the epIds array to know whether
+    //  or not it changed.  We could introduce an 'EndpointList' component whose only state was the IDs, and then
+    //  get rid of this override here and move it there (which would be a bit cleaner, since here we may add more state
+    //  and would have to remember to take it into account in this method)
+    override fun shouldComponentUpdate(nextProps: JicofoConferenceProps, nextState: JicofoConferenceState): Boolean {
+        return (state.expanded != nextState.expanded) ||
+            (state.name != nextState.name) ||
+            (!state.epIds.contentEquals(nextState.epIds) ||
+            (state.numericalKeys != nextState.numericalKeys) ||
+            (state.nonNumericalKeys != nextState.nonNumericalKeys))
+    }
+
+    override fun RBuilder.render() {
+        console.log("jicofo conference ${props.id} rendering")
+        div {
+            key = props.id
+            h2 {
+                if (state.expanded) {
+                    +"▾"
+                } else {
+                    +"▸"
+                }
+                if (state.name != undefined) {
+                    +"Conference \"${state.name}\" (${props.id})"
+                } else {
+                    +"Conference (${props.id})"
+                }
+                attrs {
+                    onClickFunction = { _ ->
+                        setState {
+                            expanded = !expanded
+                        }
+                    }
+                }
+            }
+            if (state.expanded) {
+                if (state.epIds == undefined || state.epIds.isEmpty()) {
+                    p {
+                        +"No data received yet"
+                        return
+                    }
+                }
+                styledDiv {
+                    css {
+                        paddingLeft = 2.pct
+                        paddingTop = 2.pct
+                    }
+                    child(ChartCollection::class) {
+                        attrs {
+                            numericalKeys = state.numericalKeys
+                            nonNumericalKeys = state.nonNumericalKeys
+                            data = props.confData
+                        }
+                        ref {
+                            if (it != null) {
+                                chartCollection = it as ChartCollection
+                            }
+                        }
+                    }
+                }
+                state.epIds.forEach { epId ->
+                    styledDiv {
+                        css {
+                            paddingLeft = 2.pct
+                        }
+                        key = epId
+                        child(Endpoint::class) {
+                            attrs {
+                                confId = props.id
+                                id = epId
+                                baseRestApiUrl = props.baseRestApiUrl
+                                state.dataByEp?.get(epId)?.let { existingEpData ->
+                                    data = existingEpData
+                                }
+                            }
+                            ref {
+                                if (it != null) {
+                                    eps[epId] = it as Endpoint
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // The baseRestApiUrl in props may be null, so we call this (with a non-null version) only when it isn't null
+    private suspend fun CoroutineScope.fetchDataLoop(baseRestApiUrl: String) {
+        while (isActive) {
+            try {
+                val jvbData = window.fetch("$baseRestApiUrl/${props.id}")
+                    .await()
+                    .json()
+                    .await()
+                    .asDynamic()
+                val now = jvbData.time.unsafeCast<Number>()
+                val confData = jvbData.conferences[props.id]
+                if (state.numericalKeys.isEmpty()) {
+                    extractKeys(confData)
+                }
+                confData.timestamp = now
+                chartCollection?.addData(confData)
+                val epIds = getEpIds(confData)
+                setState {
+                    this.name = confData.name.unsafeCast<String>().substringBefore('@')
+                    this.epIds = epIds
+                }
+                eps.forEach { (epId, ep) ->
+                    val epData = confData.endpoints[epId]
+                    epData.timestamp = now
+                    ep.addData(epData)
+                }
+                delay(1000)
+            } catch (c: CancellationException) {
+                console.log("Conference ${props.id} fetch loop cancelled")
+                throw c
+            } catch (t: Throwable) {
+                console.log("Conference ${props.id} fetch loop error: ", t)
+            }
+        }
+    }
+
+    private fun usingLiveData(): Boolean = props.baseRestApiUrl != null
+}
+
+private fun getEpIds(confData: dynamic): Array<String> {
+    // we only want to consider lines like this:
+    // {"endpoints":{"bca514fc":{"iceTransport":{"iceConnected":true,"num_packets_received":328,"num_packets_sent":76}...
+    // and not lines like this:
+    // {"confName":"jitsisitdown","meetingUniqueId":"804786d39ed9aba3","applicationName":"JVB","endpoints":["Lawson-rqz", ...
+    // in other words, we want to extract the endpoint stats tree root keys
+    return if (confData.participants != undefined && confData.participants !is Array<String>)
+        keys(confData.participants) else emptyArray()
+}
+
+external interface JicofoConferenceState : RState {
+    var epIds: Array<String>
+    var name: String
+    var expanded: Boolean
+    var numericalKeys: List<String>
+    var nonNumericalKeys: List<String>
+    var dataByEp: MutableMap<String, MutableList<dynamic>>?
+}
+
+external interface JicofoConferenceProps : RProps {
+    var baseRestApiUrl: String?
+    var id: String
+    var confData: List<dynamic>?
+}

--- a/src/main/kotlin/JicofoConference.kt
+++ b/src/main/kotlin/JicofoConference.kt
@@ -45,7 +45,7 @@ class JicofoConference : RComponent<JicofoConferenceProps, JicofoConferenceState
         }
         // TODO: do we know that when this method runs state.numericalKeys will always be empty?
         if (state.numericalKeys.isEmpty() && props.confData != undefined) {
-            extractKeys(props.confData!!.first())
+            extractKeys(props.confData!!)
         }
 
         if ((state.epIds == undefined || state.epIds.isEmpty()) && !usingLiveData()) {
@@ -80,10 +80,18 @@ class JicofoConference : RComponent<JicofoConferenceProps, JicofoConferenceState
         }
     }
 
-    private fun extractKeys(data: dynamic) {
+    private fun extractKeys(data: List<dynamic>) {
+        val dataList = mutableListOf<dynamic>()
+        for (i in 1 until data.size) {
+            dataList.add(data[i])
+        }
         setState {
-            numericalKeys = getAllKeysWithValuesThat(data) { it is Number }
-            nonNumericalKeys = getAllKeysWithValuesThat(data) { it !is Number }
+            numericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it is Number }
+            }.toSet().toList()
+            nonNumericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it !is Number }
+            }.toSet().toList()
         }
     }
 

--- a/src/main/kotlin/graphs/Chart.kt
+++ b/src/main/kotlin/graphs/Chart.kt
@@ -47,6 +47,7 @@ class Chart : RComponent<GraphProps, RState>() {
                         // live graphs
                         enabled = false
                     }
+                    step = "left"
                 }
             }
             chart = ChartOptions().apply {

--- a/src/main/kotlin/graphs/ChartCollection.kt
+++ b/src/main/kotlin/graphs/ChartCollection.kt
@@ -104,7 +104,7 @@ class ChartCollection : RComponent<ChartCollectionProps, ChartCollectionState>()
                                     attrs {
                                         title = "Graph ${chart.id}"
                                         allKeys = props.numericalKeys
-                                        graphType = "spline"
+                                        graphType = "line"
                                         data = props.data
                                         // TODO: ideally we'd always pull the start zoom from the value in the
                                         //  buttons, but we may not have a reference to the buttons component

--- a/src/main/kotlin/highcharts/Highcharts.kt
+++ b/src/main/kotlin/highcharts/Highcharts.kt
@@ -150,6 +150,9 @@ external interface PlotSeriesOptions {
     var marker: PointMarkerOptionsObject?
         get() = definedExternally
         set(value) = definedExternally
+    var step: String?
+        get() = definedExternally
+        set(value) = definedExternally
 }
 
 fun PlotSeriesOptions(): PlotSeriesOptions = js("{}")


### PR DESCRIPTION
- Render a jicofo dump (barebones).
- fix: No smooth lines, use step.
- fix: Extract keys from all entries at the conference level.
